### PR TITLE
Replace Freshdesk contact button with link to docs contact page

### DIFF
--- a/src/react/components/organisms/FeedbackButton.tsx
+++ b/src/react/components/organisms/FeedbackButton.tsx
@@ -4,21 +4,19 @@ import FeedbackIcon from '@mui/icons-material/Feedback';
 
 export default function FeedbackButton() {
 	return (
-		<>
-			<Tooltip title={'Contact'}>
-				<IconButton
-					component="a"
-					href="https://docs.taskratchet.com/contact.html"
-					target="_blank"
-					rel="noopener noreferrer"
-					edge="start"
-					color="inherit"
-					aria-label="contact"
-					sx={{ m: 0.1 }}
-				>
-					<FeedbackIcon />
-				</IconButton>
-			</Tooltip>
-		</>
+		<Tooltip title={'Contact'}>
+			<IconButton
+				component="a"
+				href="https://docs.taskratchet.com/contact.html"
+				target="_blank"
+				rel="noopener noreferrer"
+				edge="start"
+				color="inherit"
+				aria-label="contact"
+				sx={{ m: 0.1 }}
+			>
+				<FeedbackIcon />
+			</IconButton>
+		</Tooltip>
 	);
 }

--- a/src/react/components/organisms/FeedbackButton.tsx
+++ b/src/react/components/organisms/FeedbackButton.tsx
@@ -1,32 +1,19 @@
 import { IconButton, Tooltip } from '@mui/material';
-import React, { useEffect } from 'react';
+import React from 'react';
 import FeedbackIcon from '@mui/icons-material/Feedback';
-import { useMe } from '../../lib/api/useMe';
 
 export default function FeedbackButton() {
-	useMe({
-		onSuccess: (data) => {
-			window.FreshworksWidget('identify', 'ticketForm', {
-				name: data?.name,
-				email: data?.email,
-			});
-		},
-	});
-
-	useEffect(() => {
-		window.FreshworksWidget('hide', 'launcher');
-	}, []);
-
 	return (
 		<>
-			<Tooltip title={'Feedback'}>
+			<Tooltip title={'Contact'}>
 				<IconButton
-					onClick={() => {
-						window.FreshworksWidget('open');
-					}}
+					component="a"
+					href="https://docs.taskratchet.com/contact.html"
+					target="_blank"
+					rel="noopener noreferrer"
 					edge="start"
 					color="inherit"
-					aria-label="feedback"
+					aria-label="contact"
 					sx={{ m: 0.1 }}
 				>
 					<FeedbackIcon />


### PR DESCRIPTION
This PR converts the contact button in the main toolbar from opening a Freshdesk widget to redirecting users to the TaskRatchet documentation contact page at https://docs.taskratchet.com/contact.html.

Changes:
- Removed Freshdesk widget integration code
- Converted FeedbackButton to external link
- Updated tooltip from 'Feedback' to 'Contact'
- Added proper external link attributes (target='_blank', rel='noopener noreferrer')
- Maintained same feedback icon for visual consistency

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * The feedback button now directs users to an external contact documentation page in a new tab.

* **Style**
  * Tooltip and aria-label updated from "Feedback" to "Contact" for improved clarity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->