### PR TITLE
remove freshworks widget

### DIFF
--- a/global-setup.ts
+++ b/global-setup.ts
@@ -37,9 +37,6 @@ function deleteAllCookies() {
 const fetchMock = createFetchMock(vi);
 fetchMock.enableMocks();
 
-// window.FreshworksWidget = vi.fn() as any;
-vi.stubGlobal('FreshworksWidget', vi.fn());
-
 beforeEach(() => {
 	fetchMock.resetMocks();
 	deleteAllCookies();

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -28,25 +28,6 @@ const primaryDark = COLORS.warm.lighter,
 		</script>
 		<script src="https://js.stripe.com/v3/" type="module"></script>
 
-		<script is:inline>
-			window.fwSettings = {
-				widget_id: 150000001402,
-			};
-			!(function () {
-				if ('function' != typeof window.FreshworksWidget) {
-					var n = function () {
-						n.q.push(arguments);
-					};
-					(n.q = []), (window.FreshworksWidget = n);
-				}
-			})();
-		</script>
-		<script
-			type="text/javascript"
-			src="https://widget.freshworks.com/widgets/150000001402.js"
-			async
-			defer></script>
-
 		<link
 			rel="stylesheet"
 			href="https://fonts.googleapis.com/css?family=Roboto:300,400,500,700&display=swap"

--- a/src/react/window.d.ts
+++ b/src/react/window.d.ts
@@ -1,5 +1,4 @@
 interface Window {
-	FreshworksWidget: (...props: unknown[]) => void;
 	Stripe: (key: string) => {
 		redirectToCheckout: (
 			options: unknown,


### PR DESCRIPTION
This pull request removes the integration of the Freshworks widget from the codebase, simplifying the setup and layout files. The most important changes include the removal of the Freshworks widget initialization and its associated scripts.

### Removal of Freshworks widget integration:

* [`global-setup.ts`](diffhunk://#diff-829a9cbf949cdd4f2cea1ee4c9579d73e28aff3132091a0ce0301d592d0607c6L40-L42): Removed the stubbing of the `FreshworksWidget` global variable, which is no longer needed.
* [`src/layouts/Layout.astro`](diffhunk://#diff-ba00f1d7bc63648f0861e03d786d6f1ed78307f1b40284e4db329586d3df2db2L31-L49): Deleted the inline script and external script tags responsible for initializing and loading the Freshworks widget, as well as its configuration.