### PR TITLE
Update TaskRatchet SDK

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "@mui/material": "^5.18.0",
     "@mui/x-date-pickers": "^7.29.4",
     "@stripe/stripe-js": "^7.8.0",
-    "@taskratchet/sdk": "^6.0.1",
+    "@taskratchet/sdk": "^7.0.0",
     "dayjs": "^1.11.13",
     "humanize-duration": "^3.33.0",
     "query-string": "^9.2.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -36,8 +36,8 @@ importers:
         specifier: ^7.8.0
         version: 7.8.0
       '@taskratchet/sdk':
-        specifier: ^6.0.1
-        version: 6.0.1
+        specifier: ^7.0.0
+        version: 7.0.0
       dayjs:
         specifier: ^1.11.13
         version: 1.11.13
@@ -207,8 +207,8 @@ packages:
     resolution: {integrity: sha512-KHp2IflsnGywDjBWDkR9iEqiWSpc8GIi0lgTT3mOElT0PP1tG26P4tmFI2YvAdzgq9RGyoHZQEIEdZy6Ec5xCA==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/runtime@7.28.3':
-    resolution: {integrity: sha512-9uIQ10o0WGdpP6GDhXcdOJPJuDgFtIDtN/9+ArJQ2NAfAmiuhTQdzkaTGR33v43GYS2UrSA0eX2pPPHoFVvpxA==}
+  '@babel/runtime@7.28.4':
+    resolution: {integrity: sha512-Q/N6JNWvIvPnLDvjlE1OUBLPQHH6l3CltCEsHIujp45zQUSSh8K+gHnaEX45yAT1nyngnINhvWtzN+Nb9D8RAQ==}
     engines: {node: '>=6.9.0'}
 
   '@babel/template@7.27.2':
@@ -1133,8 +1133,8 @@ packages:
     resolution: {integrity: sha512-DNXRfYUgkZlrniQORbA/wH8CdFRhiBSE0R56gYU0V5vvpJ9WZwvGrz9tBAZmfq2aTgw6SK7mNpmTizGzLWVezw==}
     engines: {node: '>=12.16'}
 
-  '@taskratchet/sdk@6.0.1':
-    resolution: {integrity: sha512-OJ2DW0F6+gowWnb15f4Dpy3J5z1oD/gEEsbcrsvEgVr5dpPuR805erI0cF4uMk2G/Tiku4aMcehWMCGaYcKewQ==}
+  '@taskratchet/sdk@7.0.0':
+    resolution: {integrity: sha512-n0BHr1OxElt39nrKLEJPaNXgwjUxT0wiBYrR1GdI+JPjkgIVQpSqzzlS08YdcMbMtGzzZ/7Y4dVLfGxNM4pJ2Q==}
 
   '@testing-library/dom@10.4.0':
     resolution: {integrity: sha512-pemlzrSESWbdAloYml3bAJMEfNh1Z7EduzqPKprCH5S341frlpYnUEW0H72dLxa6IsYr+mPno20GiSm+h9dEdQ==}
@@ -3145,7 +3145,7 @@ snapshots:
 
   '@babel/runtime@7.28.2': {}
 
-  '@babel/runtime@7.28.3': {}
+  '@babel/runtime@7.28.4': {}
 
   '@babel/template@7.27.2':
     dependencies:
@@ -3864,12 +3864,12 @@ snapshots:
 
   '@stripe/stripe-js@7.8.0': {}
 
-  '@taskratchet/sdk@6.0.1': {}
+  '@taskratchet/sdk@7.0.0': {}
 
   '@testing-library/dom@10.4.0':
     dependencies:
       '@babel/code-frame': 7.27.1
-      '@babel/runtime': 7.28.3
+      '@babel/runtime': 7.28.4
       '@types/aria-query': 5.0.4
       aria-query: 5.3.0
       chalk: 4.1.2

--- a/src/components/organisms/NavBar.tsx
+++ b/src/components/organisms/NavBar.tsx
@@ -11,7 +11,7 @@ import {
 	Tooltip,
 	Typography,
 } from '@mui/material';
-import { setAuthToken } from '@taskratchet/sdk';
+import { setAuthTokenGetter } from '@taskratchet/sdk';
 import { useEffect } from 'react';
 import { Link } from 'react-router-dom';
 import { useNavigate } from 'react-router-dom';
@@ -34,13 +34,11 @@ export default function NavBar({ onTodayClick }: NavBarProps): JSX.Element {
 	const clerk = useClerk();
 
 	useEffect(() => {
-		if (!isSignedIn || !user) {
-			setAuthToken(null);
-			return;
-		}
-
-		void clerk.session?.getToken().then((t) => {
-			setAuthToken(t ?? null);
+		setAuthTokenGetter(async () => {
+			if (!isSignedIn || !user) {
+				return null;
+			}
+			return (await clerk.session?.getToken()) ?? null;
 		});
 	}, [isSignedIn, user, clerk]);
 


### PR DESCRIPTION
This updates the TaskRatchet SDK dependency, hopefully fixing an issue with the web app using stale clerk auth tokens.