### PR TITLE
remove outdated route rewrites

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -9,11 +9,5 @@ services:
       - app.taskratchet.com
     routes:
       - type: rewrite
-        source: /login
-        destination: /login/index.html
-      - type: rewrite
-        source: /register
-        destination: /register/index.html
-      - type: rewrite
         source: /*
         destination: /


### PR DESCRIPTION
There were old route rewrites from when we were using astro that are no longer necessary and were breaking the new path redirects. This PR removes the old rewrites.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Simplified request routing by consolidating path rewrites into a single catch-all route.
  - Login and registration pages now resolve through the main application route.

- **Impact**
  - Navigation to /login and /register continues to work as expected.
  - No changes to other routes or overall app behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->