### PR TITLE
set redirectUrl on auth routes

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -122,9 +122,15 @@ export function App(): JSX.Element {
 										element={<Register />}
 									/>
 
-									<Route path={'/login'} element={<RedirectToSignIn />} />
+									<Route
+										path={'/login'}
+										element={<RedirectToSignIn redirectUrl={'/'} />}
+									/>
 
-									<Route path={'/register'} element={<RedirectToSignUp />} />
+									<Route
+										path={'/register'}
+										element={<RedirectToSignUp redirectUrl={'/'} />}
+									/>
 
 									<Route
 										path={'/'}


### PR DESCRIPTION
Currently visiting /login and /register results in a redirect loop since clerk redirects back to /login and /register. This explicitly sets redirect urls on these routes to avoid the loop.