### PR TITLE
invalidate query cache on auth change

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "react-toastify": "^10.0.6"
   },
   "devDependencies": {
+    "@clerk/types": "^4.89.0",
     "@eslint/compat": "^1.3.2",
     "@eslint/eslintrc": "^3.3.1",
     "@eslint/js": "^9.33.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -69,6 +69,9 @@ importers:
         specifier: ^10.0.6
         version: 10.0.6(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
     devDependencies:
+      '@clerk/types':
+        specifier: ^4.89.0
+        version: 4.89.0
       '@eslint/compat':
         specifier: ^1.3.2
         version: 1.3.2(eslint@9.33.0(jiti@2.5.1))
@@ -246,8 +249,8 @@ packages:
     resolution: {integrity: sha512-W1HTKq3tFJGU/YMFDnoiy3DKU2N9OnChDScNzuiRpjvNpOspQ/GVhRKUqPUvxawnHsPd6vQ+UFJAKAbb+XfEaA==}
     engines: {node: '>=18.17.0'}
 
-  '@clerk/types@4.75.0':
-    resolution: {integrity: sha512-b5bL+XhV4ZO7Q54YqsxV4LyopaWuV0fzg6acsYD5mM2ibQaVY/SIAQgH40sGBT1D25c2jyvVY2JDKPRPqB1I5g==}
+  '@clerk/types@4.89.0':
+    resolution: {integrity: sha512-4pT8s/f05C3w1ggRvF12Vr+Ms8GisVBNoWG56znGuofoQ4pzLhJJTU6daVCxTjkPf30IlYtQfoAUaKjXDwH/rw==}
     engines: {node: '>=18.17.0'}
 
   '@csstools/color-helpers@5.0.2':
@@ -3173,14 +3176,14 @@ snapshots:
   '@clerk/clerk-react@5.41.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@clerk/shared': 3.19.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@clerk/types': 4.75.0
+      '@clerk/types': 4.89.0
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
       tslib: 2.8.1
 
   '@clerk/shared@3.19.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
-      '@clerk/types': 4.75.0
+      '@clerk/types': 4.89.0
       dequal: 2.0.3
       glob-to-regexp: 0.4.1
       js-cookie: 3.0.5
@@ -3192,10 +3195,10 @@ snapshots:
 
   '@clerk/themes@2.4.7':
     dependencies:
-      '@clerk/types': 4.75.0
+      '@clerk/types': 4.89.0
       tslib: 2.8.1
 
-  '@clerk/types@4.75.0':
+  '@clerk/types@4.89.0':
     dependencies:
       csstype: 3.1.3
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -27,6 +27,7 @@ import Settings from './components/pages/Settings';
 import Tasks from './components/pages/Tasks';
 import * as browser from './lib/browser';
 import getQueryClient from './lib/getQueryClient';
+import { useOnClerkEvent } from './lib/useOnClerkEvent';
 
 const PUBLISHABLE_KEY = import.meta.env.VITE_CLERK_PUBLISHABLE_KEY;
 
@@ -39,6 +40,10 @@ export function App(): JSX.Element {
 	const ref = useRef<HTMLElement>();
 	const location = useLocation();
 	const queryClient = getQueryClient();
+
+	useOnClerkEvent(() => {
+		void queryClient.invalidateQueries();
+	});
 
 	const handleTodayClick = () => {
 		setLastToday(browser.getNowDate());

--- a/src/lib/useOnClerkEvent.ts
+++ b/src/lib/useOnClerkEvent.ts
@@ -1,0 +1,15 @@
+import { useClerk } from '@clerk/clerk-react';
+import type { ListenerCallback } from '@clerk/types';
+import { useEffect } from 'react';
+
+export function useOnClerkEvent(callback: ListenerCallback) {
+	const clerk = useClerk();
+
+	useEffect(() => {
+		if (!clerk) return;
+		const unsubscribe = clerk.addListener(({ user, session, client }) => {
+			callback({ user, session, client });
+		});
+		return unsubscribe;
+	}, [clerk, callback]);
+}


### PR DESCRIPTION
Currently it seems that if clerk auth changes, the data in the react query cache remains stale. This should invalidate the whole cache on clerk auth change.